### PR TITLE
Ensure negative positive BigInts are padded if their first byte has 0x80

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -24,13 +24,20 @@ BigInt decodeBigInt(List<int> bytes) {
 }
 
 var _byteMask = BigInt.from(0xff);
+final negativeFlag = BigInt.from(0x80);
 
 /// Encode a BigInt into bytes using big-endian encoding.
 Uint8List encodeBigInt(BigInt number) {
   // Not handling negative numbers. Decide how you want to do that.
-  var size = (number.bitLength + 7) >> 3;
+  var rawSize = (number.bitLength + 7) >> 3;
+  // If the first byte has 0x80 set, we need an extra byte
+  final needsPaddingByte = number > BigInt.from(0) &&
+          ((number >> (rawSize - 1) * 8) & negativeFlag) == negativeFlag
+      ? 1
+      : 0;
+  final size = rawSize + needsPaddingByte;
   var result = Uint8List(size);
-  for (var i = 0; i < size; i++) {
+  for (var i = 0; i < rawSize; i++) {
     result[size - i - 1] = (number & _byteMask).toInt();
     number = number >> 8;
   }


### PR DESCRIPTION
Encoding a BigInt in 2s-compliment requires an extra padding byte if the
0x80 bit is set in the first byte position. This commit checks to see if
that's the case, and adds the padding to ensure it is parseable.